### PR TITLE
RC07 레시피 목록 좋아요순 조회 개발

### DIFF
--- a/src/main/java/toy/recipit/common/Constants.java
+++ b/src/main/java/toy/recipit/common/Constants.java
@@ -98,4 +98,9 @@ public final class Constants {
         String DRAFT = "RS3";
         String DELETED = "RS4";
     }
+
+    public interface SortType {
+        String RECENT = "RECENT";
+        String LIKE = "LIKE";
+    }
 }

--- a/src/main/java/toy/recipit/controller/RecipeController.java
+++ b/src/main/java/toy/recipit/controller/RecipeController.java
@@ -89,4 +89,19 @@ public class RecipeController {
 
         return ResponseEntity.ok(apiResponseFactory.success(recipeService.getRecentRecipes(userNo, requestDto)));
     }
+
+    @GetMapping("/list/like-order")
+    public ResponseEntity<ApiResponse<RecipeListDto>> getLikeRecipeList(
+            HttpServletRequest request,
+            GetRecipeListDto requestDto
+    ) {
+        String userNo = StringUtil.EMPTY_STRING;
+
+        if(sessionUtil.isSessionExists(request)) {
+            SessionUserInfo userInfo = sessionUtil.getSessionUserInfo(request);
+            userNo = userInfo.getUserNo();
+        }
+
+        return ResponseEntity.ok(apiResponseFactory.success(recipeService.getLikeRecipes(userNo, requestDto)));
+    }
 }

--- a/src/main/java/toy/recipit/mapper/RecipeMapper.java
+++ b/src/main/java/toy/recipit/mapper/RecipeMapper.java
@@ -30,13 +30,14 @@ public interface RecipeMapper {
                     @Param("recipeNo") String recipeNo,
                     @Param("likeYn") String likeYn);
 
-    List<SearchRecipeVo> getRecentRecipes(@Param("userNo") String userNo,
-                                          @Param("categoryCode") String categoryCode,
-                                          @Param("keyword") String keyword,
-                                          @Param("offset") int offset,
-                                          @Param("size") int size,
-                                          @Param("imageTypeCode") String imageTypeCode,
-                                          @Param("difficultyGroupCode") String difficultyGroupCode);
+    List<SearchRecipeVo> getRecipes(@Param("userNo") String userNo,
+                                    @Param("categoryCode") String categoryCode,
+                                    @Param("keyword") String keyword,
+                                    @Param("offset") int offset,
+                                    @Param("size") int size,
+                                    @Param("imageTypeCode") String imageTypeCode,
+                                    @Param("difficultyGroupCode") String difficultyGroupCode,
+                                    @Param("sortType") String sortType);
 
     List<CommonDetailCodeVo> getRecipeCategories(@Param("keyword") String keyword,
                                                 @Param("categoryGroupCode") String categoryGroupCode);

--- a/src/main/java/toy/recipit/service/RecipeService.java
+++ b/src/main/java/toy/recipit/service/RecipeService.java
@@ -70,16 +70,36 @@ public class RecipeService {
     }
 
     public RecipeListDto getRecentRecipes(String userNo, GetRecipeListDto getRecipeListDto) {
-        List<SearchRecipeVo> recipeVoList = recipeMapper.getRecentRecipes(
+        List<SearchRecipeVo> recipeVoList = recipeMapper.getRecipes(
                 userNo,
                 getRecipeListDto.getCategoryCode(),
                 getRecipeListDto.getKeyword(),
                 (getRecipeListDto.getPage() - 1) * getRecipeListDto.getSize(),
                 getRecipeListDto.getSize(),
                 Constants.Image.THUMBNAIL,
-                Constants.GroupCode.DIFFICULTY
+                Constants.GroupCode.DIFFICULTY,
+                Constants.SortType.RECENT
         );
 
+        return createRecipeListDto(recipeVoList, getRecipeListDto);
+    }
+
+    public RecipeListDto getLikeRecipes(String userNo, GetRecipeListDto getRecipeListDto) {
+        List<SearchRecipeVo> recipeVoList = recipeMapper.getRecipes(
+                userNo,
+                getRecipeListDto.getCategoryCode(),
+                getRecipeListDto.getKeyword(),
+                (getRecipeListDto.getPage() - 1) * getRecipeListDto.getSize(),
+                getRecipeListDto.getSize(),
+                Constants.Image.THUMBNAIL,
+                Constants.GroupCode.DIFFICULTY,
+                Constants.SortType.LIKE
+        );
+
+        return createRecipeListDto(recipeVoList, getRecipeListDto);
+    }
+
+    private RecipeListDto createRecipeListDto(List<SearchRecipeVo> recipeVoList, GetRecipeListDto getRecipeListDto) {
         List<RecipeDto> recipelist = recipeVoList.stream()
                 .map(searchRecipeVo -> new RecipeDto(
                         searchRecipeVo.getRecipeNo(),

--- a/src/main/resources/mapper/RecipeMapper.xml
+++ b/src/main/resources/mapper/RecipeMapper.xml
@@ -80,7 +80,7 @@
             )
     </insert>
 
-    <select id="getRecentRecipes"
+    <select id="getRecipes"
             resultType="toy.recipit.mapper.vo.SearchRecipeVo">
         SELECT
             R.RECIPE_NO        AS recipeNo,
@@ -127,7 +127,14 @@
             </if>
         </where>
         GROUP BY R.RECIPE_NO
-        ORDER BY R.RECIPE_NO DESC
+        <choose>
+            <when test="sortType == 'LIKE'">
+                ORDER BY likeCount DESC, R.RECIPE_NO DESC
+            </when>
+            <otherwise>
+                ORDER BY R.RECIPE_NO DESC
+            </otherwise>
+        </choose>
         LIMIT #{offset}, #{size}
     </select>
 


### PR DESCRIPTION
레시피 목록을 좋아요순으로 정렬하여 보여주는 API입니다. 좋아요 수가 동일한 경우 최신순으로 정렬합니다.

RC06 레시피 목록 최신순 조회와 서비스 부분과 mapper 부분에서 중복되는 코드가 많아 서비스는 공통 부분은 메서드화 하여 중복 코드를 줄였습니다.
mapper도 orderBy부분의 차이만 있기 때문에 동적쿼리를 활용하였습니다.