### PR TITLE
닉네임 변경 API 세션 갱신 누락 수정

### DIFF
--- a/src/main/java/toy/recipit/controller/UserController.java
+++ b/src/main/java/toy/recipit/controller/UserController.java
@@ -261,6 +261,14 @@ public class UserController {
     ) {
         SessionUserInfo userInfo = sessionUtil.getSessionUserInfo(request);
 
+        SessionUserInfo changeUserInfo = new SessionUserInfo(
+                userInfo.getUserNo(),
+                changeNicknameDto.getNickname(),
+                Constants.UserStatus.ACTIVE
+        );
+
+        sessionUtil.setSessionUserInfo(request, changeUserInfo);
+
         return ResponseEntity.ok(apiResponseFactory.success(userService.changeNickname(userInfo.getUserNo(), changeNicknameDto)));
     }
 

--- a/src/main/java/toy/recipit/controller/UserController.java
+++ b/src/main/java/toy/recipit/controller/UserController.java
@@ -258,18 +258,22 @@ public class UserController {
     public ResponseEntity<ApiResponse<Boolean>> changeNickname(
             HttpServletRequest request,
             @RequestBody @Valid ChangeNicknameDto changeNicknameDto
-    ) {
+    ) throws Exception {
         SessionUserInfo userInfo = sessionUtil.getSessionUserInfo(request);
 
-        SessionUserInfo changeUserInfo = new SessionUserInfo(
-                userInfo.getUserNo(),
-                changeNicknameDto.getNickname(),
-                Constants.UserStatus.ACTIVE
-        );
+        if (userService.changeNickname(userInfo.getUserNo(), changeNicknameDto)) {
+            SessionUserInfo changeUserInfo = new SessionUserInfo(
+                    userInfo.getUserNo(),
+                    changeNicknameDto.getNickname(),
+                    Constants.UserStatus.ACTIVE
+            );
 
-        sessionUtil.setSessionUserInfo(request, changeUserInfo);
+            sessionUtil.setSessionUserInfo(request, changeUserInfo);
 
-        return ResponseEntity.ok(apiResponseFactory.success(userService.changeNickname(userInfo.getUserNo(), changeNicknameDto)));
+            return ResponseEntity.ok(apiResponseFactory.success(true));
+        }
+
+       throw new Exception();
     }
 
     @GetMapping("/notification/list")


### PR DESCRIPTION
닉네임 변경 시 세션에 저장되어 있는 사용자 정보의 갱신이 누락되어 추가했습니다.